### PR TITLE
实现监视模式

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -28,9 +28,9 @@
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle13 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle14 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle15 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
             this.button1 = new System.Windows.Forms.Button();
             this.button2 = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
@@ -43,6 +43,7 @@
             this.button3 = new System.Windows.Forms.Button();
             this.button4 = new System.Windows.Forms.Button();
             this.label4 = new System.Windows.Forms.Label();
+            this.button5 = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
             this.SuspendLayout();
             // 
@@ -95,8 +96,8 @@
             // 
             // ip
             // 
-            dataGridViewCellStyle13.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            this.ip.DefaultCellStyle = dataGridViewCellStyle13;
+            dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            this.ip.DefaultCellStyle = dataGridViewCellStyle4;
             this.ip.HeaderText = "IP地址";
             this.ip.Name = "ip";
             this.ip.ToolTipText = "Steam CDN服务器的IP地址";
@@ -104,8 +105,8 @@
             // 
             // time
             // 
-            dataGridViewCellStyle14.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            this.time.DefaultCellStyle = dataGridViewCellStyle14;
+            dataGridViewCellStyle5.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            this.time.DefaultCellStyle = dataGridViewCellStyle5;
             this.time.HeaderText = "页面打开时间";
             this.time.Name = "time";
             this.time.ToolTipText = "从连接服务器到获取到首页代码的时间";
@@ -113,8 +114,8 @@
             // 
             // location
             // 
-            dataGridViewCellStyle15.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            this.location.DefaultCellStyle = dataGridViewCellStyle15;
+            dataGridViewCellStyle6.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            this.location.DefaultCellStyle = dataGridViewCellStyle6;
             this.location.HeaderText = "IP地理位置";
             this.location.Name = "location";
             this.location.ToolTipText = "IP地址的地理位置";
@@ -169,11 +170,22 @@
             this.label4.TabIndex = 10;
             this.label4.Text = "（测试中...）";
             // 
+            // button5
+            // 
+            this.button5.Location = new System.Drawing.Point(38, 642);
+            this.button5.Name = "button5";
+            this.button5.Size = new System.Drawing.Size(132, 40);
+            this.button5.TabIndex = 11;
+            this.button5.Text = "启用监视";
+            this.button5.UseVisualStyleBackColor = true;
+            this.button5.Click += new System.EventHandler(this.button5_Click);
+            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(11F, 24F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(744, 694);
+            this.Controls.Add(this.button5);
             this.Controls.Add(this.label4);
             this.Controls.Add(this.button4);
             this.Controls.Add(this.button3);
@@ -209,6 +221,7 @@
         private System.Windows.Forms.Button button3;
         private System.Windows.Forms.Button button4;
         private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.Button button5;
     }
 }
 

--- a/Form1.cs
+++ b/Form1.cs
@@ -134,7 +134,6 @@ namespace SteamHosts
             t.Elapsed += (tsender, te) =>
             {
                 BeginInvoke(new OnWatchModeDelegate(OnWatchMode));
-                //TODO:记录数据到json
             };
             t.AutoReset = true;
         }


### PR DESCRIPTION
针对间歇性的网络中断，实现一个简单的监视模式。
每隔15秒重新对当前hosts进行网络测试，如果成功，则继续使用；如果失败，则在上次完整测试的数据中选择一个临时的经测试可用的hosts并启用（因为是使用time字符串进行排序，所以理论上应该会选择大于1000ms的最小值），在使用临时hosts的这段时间内重新进行一次完整测试，选择延迟最小的ip并启用，然后重新进入监视状态。